### PR TITLE
fix: When visiting sequences the name was passed as null which led to parameter null exception. Fixed so that available name is passed.

### DIFF
--- a/MhLabs.SerilogExtensions.Tests/Formatters/MhSensitivePropertyValueFormatterTests.cs
+++ b/MhLabs.SerilogExtensions.Tests/Formatters/MhSensitivePropertyValueFormatterTests.cs
@@ -71,5 +71,37 @@ namespace MhLabs.SerilogExtensions.Tests.Formatters
             Assert.Equal(new ScalarValue(expected), result.Value);
         }
 
+
+        [Fact]
+        public void Test_Format_Sequence()
+        {
+            // arrange
+            var name = "Scope";
+            var sequenceValue = "HTTP POST https://apigateway.mhdev.se/member-service/int/v2.0/members";
+
+            var scalar = new SequenceValue(new List<LogEventPropertyValue> { new ScalarValue(sequenceValue) });
+
+            var logEventProperty = new LogEventProperty(name, scalar);
+            var structureValue = new StructureValue(new List<LogEventProperty> { logEventProperty });
+            var _formatter = new MhSensitivePropertyValueFormatter();
+
+            var logEvent = new LogEvent(
+                new System.DateTimeOffset(),
+                LogEventLevel.Information,
+                null,
+                new MessageTemplate("", new List<MessageTemplateToken>()),
+                new List<LogEventProperty> { new LogEventProperty("BaseModel", structureValue) });
+
+            // act
+            _formatter.Format(logEvent);
+
+            var baseModel = logEvent.Properties["BaseModel"] as StructureValue;
+            var result = baseModel.Properties[0];
+
+            // assert
+            Assert.Equal(name, result.Name);
+            Assert.NotNull(result.Value);
+        }
+
     }
 }

--- a/MhLabs.SerilogExtensions/Formatters/MhSensitivePropertyValueFormatter.cs
+++ b/MhLabs.SerilogExtensions/Formatters/MhSensitivePropertyValueFormatter.cs
@@ -81,7 +81,7 @@ namespace MhLabs.SerilogExtensions
 
         private LogEventProperty VisitSequence(string name, SequenceValue sequence)
         {
-            var elements = sequence.Elements.Select(e => Visit(null, e).Value);
+            var elements = sequence.Elements.Select(e => Visit(name, e).Value);
             return new LogEventProperty(name, new SequenceValue(elements));
         }
 

--- a/MhLabs.SerilogExtensions/MhLabs.SerilogExtensions.csproj
+++ b/MhLabs.SerilogExtensions/MhLabs.SerilogExtensions.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <Version>1.6.0</Version>
+    <Version>1.6.1</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   </PropertyGroup>
 


### PR DESCRIPTION
fix: When visiting sequences the name was passed as null which led to parameter null exception. Fixed so that available name is passed.